### PR TITLE
fix: Resize team images

### DIFF
--- a/components/pages/help/TeamSection.vue
+++ b/components/pages/help/TeamSection.vue
@@ -12,7 +12,7 @@
           :src="
             require(`../../../assets/images/${member.name
               .toLowerCase()
-              .replace(' ', '-')}.jpg`)
+              .replace(' ', '-')}.jpg?resize&size=240&format=webp`)
           "
           class="w-1/2 mx-auto mb-4 md:ml-0 md:mb-0 md:mr-4 md:w-4/12 h-fit aspect-square object-cover"
         />


### PR DESCRIPTION
# TIB Landing PR

## Changes

A brief list of changes

- Team images are now smaller in size and in webp format
